### PR TITLE
Updated Editor Notch Height Call

### DIFF
--- a/QuorumStudio/SourceCode/Interface/Controls/CodeEditorTabPane.quorum
+++ b/QuorumStudio/SourceCode/Interface/Controls/CodeEditorTabPane.quorum
@@ -269,7 +269,7 @@ class CodeEditorTabPane is TabPane, TabChangeListener
         editor:SetFontSize(size)
         editor:SetBlockNotchTopWidth(40)
         editor:SetBlockNotchBottomWidth(20)
-        editor:SetBlockNotchHeight(5)
+        editor:SetBlockNotchPercentageHeight(5)
         InputTable table = game:GetInputTable(editor:CODE_EDITOR_INPUT_GROUP)
         if firstTimeBlockEditorOpened //can't be undefined, because it's in the standard library now
             //table = editor:CopyAndActivateInputTable(editor:CODE_EDITOR_INPUT_GROUP)


### PR DESCRIPTION
I was attempting to build QuorumStudio and it states that SetBlockNotchHeight does not exist. I updated this to SetBlockNotchPercentageHeight, allowing me to build and run QuorumStudio.